### PR TITLE
refactor: limit bid workflow to skeleton and specs

### DIFF
--- a/backend/agents/coordinator.py
+++ b/backend/agents/coordinator.py
@@ -16,23 +16,20 @@ class CoordinatorAgent(BaseAgent):
 📋 **核心职责**：
 1. **会话管理**: 与用户进行自然语言对话，协调整个招标文件处理流程
 2. **意图识别与任务分派**: 分析用户需求，判断是否需要处理招标文件
-3. **A-E工作流协调**: 管理最小落地版A-E流程的完整执行
+3. **工作流协调**: 管理结构抽取与技术规格提取流程的执行
 4. **状态管理**: 维护文件处理状态，更新项目进度
 5. **用户交互**: 引导用户确认流程节点，收集反馈和修改意见
 
-🤖 **A-E专业智能体团队**：
+🤖 **智能体团队**：
 - 🏗️ **A - StructureExtractor**: 结构抽取，从招标文件提取投标文件格式要求，生成投标文件骨架
 - 📋 **B - SpecExtractor**: 技术规格书抽取，精准定位并提取第四章技术规格书内容
-- 📝 **C - PlanOutliner**: 方案提纲生成，根据技术规格书生成技术方案和施工方法的详细提纲
-- 🔧 **D - BidAssembler**: 投标文件拼装，将骨架、方案提纲和技术规格书进行智能拼装生成草案
-- ✅ **E - SanityChecker**: 完整性校验，检查投标文件草案的完整性和合规性
 
-💼 **A-E工作流程**：
-A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼装草案 → E：完整性校验
+💼 **当前工作流程**：
+A：结构抽取 → B：技术规格书
 
 📊 **状态管理**：使用 ✅已完成、🚧进行中、⏳待处理 来标记任务状态
 
-🎯 **目标**: 通过A-E工作流帮助用户高效处理招标文件，自动生成专业的投标方案。"""
+🎯 **目标**: 通过该工作流帮助用户高效处理招标文件，生成基础的投标文件骨架和技术规格书。"""
     
     async def execute(self, context: AgentContext) -> AgentResponse:
         try:
@@ -45,9 +42,9 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
             # 根据当前阶段决定下一步行动
             if current_stage == "initial":
                 return await self._handle_initial_request(context)
-            elif current_stage == "parsing_requested":
-                # 处理文档解析请求，明确清除此状态并推进
-                context.project_state["current_stage"] = "document_parsing"  # 立即推进状态
+            elif current_stage in ("parsing_requested", "parsing_completed"):
+                # 处理文档解析请求或解析完成后继续执行工作流
+                context.project_state["current_stage"] = "document_parsing" if current_stage == "parsing_requested" else current_stage
                 return await self._coordinate_bid_build(context)
             else:
                 return await self._handle_general_coordination(context)
@@ -84,7 +81,7 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
         analysis = await self._analyze_user_request(context)
         
         if analysis["action"] in ["process_bidding_documents", "process_documents"]:
-            # 开始招标文件处理流程，直接触发A-E工作流
+            # 开始招标文件处理流程，直接触发工作流
             return await self._coordinate_bid_build(context)
         else:
             # 一般对话处理
@@ -95,7 +92,7 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
         user_text = (context.user_input or "").strip()
         current_stage = context.project_state.get("current_stage", "initial")
         
-        # 触发词：继续执行/开始/执行/生成模板 → 直接推进到A-E工作流
+        # 触发词：继续执行/开始/执行/生成模板 → 直接推进到工作流
         trigger_keywords = ["继续", "继续执行", "开始", "执行", "生成模板"]
         if any(k in user_text for k in trigger_keywords):
             return await self._coordinate_bid_build(context)
@@ -117,7 +114,7 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
         )
 
     async def _coordinate_bid_build(self, context: AgentContext) -> AgentResponse:
-        """协调最小落地版 A–E 工作流（结构→规格→提纲→拼装→校验）"""
+        """协调简化版工作流（结构→规格）"""
         context.project_state = context.project_state or {}
         
         # 检查是否有上传文件且未进行文档解析
@@ -140,7 +137,7 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
             
             # 返回解析结果，让用户知道文档已解析完成
             return AgentResponse(
-                content=parse_result.content + "\n\n🚀 **接下来将启动A-E工作流进行投标文件生成...**",
+                content=parse_result.content + "\n\n🚀 **接下来将启动工作流进行投标文件生成...**",
                 metadata={
                     "current_agent": "document_parser",
                     "stage": "parsing_completed",  # 使用完成状态而不是进行中状态
@@ -151,8 +148,8 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
                 next_actions=[]  # 清空next_actions避免继续循环
             )
         
-        # 如果没有上传文件，直接使用默认模板执行A-E工作流
-        # 优先使用文档解析产出的标准路径；若不存在，则依然允许A–E以兜底模板运行
+        # 如果没有上传文件，直接使用默认模板执行工作流
+        # 优先使用文档解析产出的标准路径；若不存在，则依然允许流程以兜底模板运行
         from app_core.config import settings
         tender_path = (
             (context.project_state or {}).get("tender_path")
@@ -167,10 +164,6 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
             context.project_state.update({
                 "outline_path": result.get("outline_path"),
                 "spec_path": result.get("spec_path"),
-                "plan_path": result.get("plan_path"),
-                "plan_draft_path": result.get("plan_draft_path"),
-                "draft_path": result.get("draft_path"),
-                "sanity_report_path": result.get("sanity_report_path"),
                 "current_stage": "bid_build_completed",
             })
 
@@ -178,13 +171,9 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
             created = [
                 ("投标文件_骨架.md", result.get("outline_path")),
                 ("技术规格书_提取.md", result.get("spec_path")),
-                ("方案_提纲.md", result.get("plan_path")),
-                ("方案_草稿.md", result.get("plan_draft_path")),
-                ("投标文件_草案.md", result.get("draft_path")),
-                ("sanity_report.json", result.get("sanity_report_path")),
             ]
             lines = [f"- {name}: {path}" for name, path in created if path]
-            msg = "\n".join(["✅ 已完成最小链路（A–E）生成以下文件:"] + lines)
+            msg = "\n".join(["✅ 已生成以下文件:"] + lines)
 
             return AgentResponse(
                 content=msg,
@@ -198,7 +187,7 @@ A：结构抽取 → B：技术规格书 → C：方案提纲/草稿 → D：拼
         except Exception as e:
             context.project_state["current_stage"] = "bid_build_failed"
             return AgentResponse(
-                content=f"❌ A–E 工作流执行失败: {str(e)}",
+                content=f"❌ 工作流执行失败: {str(e)}",
                 metadata={
                     "current_agent": "coordinator",
                     "stage": "bid_build_failed",

--- a/backend/api/v1/endpoints/pipeline.py
+++ b/backend/api/v1/endpoints/pipeline.py
@@ -1,5 +1,5 @@
 """
-Pipeline API endpoints for A–E workflow execution (interactive and non-interactive)
+Pipeline API endpoints for structure/spec workflow execution (interactive and non-interactive)
 """
 from typing import Dict, Any, Optional, List
 from fastapi import APIRouter, HTTPException
@@ -7,12 +7,9 @@ from pydantic import BaseModel
 import asyncio
 from datetime import datetime
 
-from workflow.bid_build_graph import run_build_async, run_build_sequential_async
+from workflow.bid_build_graph import run_build_sequential_async
 from agents.structure_extractor import StructureExtractor
 from agents.spec_extractor import SpecExtractor
-from agents.plan_outliner import PlanOutliner
-from agents.bid_assembler import BidAssembler
-from agents.sanity_checker import SanityChecker
 
 
 router = APIRouter()
@@ -37,13 +34,8 @@ def _summarize_state(state: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "outline_path": state.get("outline_path"),
         "spec_path": state.get("spec_path"),
-        "plan_path": state.get("plan_path"),
-        "plan_draft_path": state.get("plan_draft_path"),
-        "draft_path": state.get("draft_path"),
-        "sanity_report_path": state.get("sanity_report_path"),
         "outline_confirmed": state.get("outline_confirmed"),
         "spec_confirmed": state.get("spec_confirmed"),
-        "plan_confirmed": state.get("plan_confirmed"),
         "current_step": state.get("current_step"),
         "waiting_for_confirmation": state.get("waiting_for_confirmation", False),
     }
@@ -58,8 +50,6 @@ class StartWorkflowRequest(BaseModel):
     interactive: bool = False
     auto_confirm: bool = True
     recursion_limit: int = 50
-    solution_requirements: Optional[str] = None
-    user_input: Optional[str] = None
 
 
 class StartWorkflowResponse(BaseModel):
@@ -73,9 +63,6 @@ class ContinueWorkflowRequest(BaseModel):
     session_id: str
     outline_confirmed: Optional[bool] = None
     spec_confirmed: Optional[bool] = None
-    plan_confirmed: Optional[bool] = None
-    solution_requirements: Optional[str] = None
-    user_input: Optional[str] = None
 
 
 class ContinueWorkflowResponse(BaseModel):
@@ -113,36 +100,7 @@ async def _run_interactive_until_pause(state: Dict[str, Any]) -> Dict[str, Any]:
     state["spec_confirmed"] = True
     state["waiting_for_confirmation"] = False
 
-    # 3) 等待方案输入
-    if interactive:
-        if not state.get("solution_requirements") and not state.get("user_input"):
-            state["waiting_for_confirmation"] = True
-            state["current_step"] = "solution_input"
-            return state
-
-    # 3.1) 兼容：将 solution_requirements 映射到 user_input
-    if state.get("solution_requirements") and not state.get("user_input"):
-        state["user_input"] = state["solution_requirements"]
-
-    # 4) 技术方案生成（PlanOutliner 复用）
-    if not state.get("plan_path"):
-        state = PlanOutliner().execute(state)
-
-    # 4.1) 确认技术方案
-    if interactive and not state.get("plan_confirmed"):
-        state["waiting_for_confirmation"] = True
-        state["current_step"] = "solution_confirmation"
-        return state
-    state["plan_confirmed"] = True
-    state["waiting_for_confirmation"] = False
-
-    # 5) 拼装与校验
-    if not state.get("draft_path"):
-        state = BidAssembler().execute(state)
-
-    if not state.get("sanity_report_path"):
-        state = SanityChecker().execute(state)
-
+    # 3) 流程结束
     state["current_step"] = "completed"
     return state
 
@@ -163,12 +121,8 @@ async def start_workflow(request: StartWorkflowRequest):
             "interactive": bool(request.interactive),
             "auto_confirm": bool(request.auto_confirm),
         })
-        if request.solution_requirements and not state.get("solution_requirements"):
-            state["solution_requirements"] = request.solution_requirements
-        if request.user_input and not state.get("user_input"):
-            state["user_input"] = request.user_input
 
-        # 非交互：直接跑完整 A–E（顺序执行，避免图递归）
+        # 非交互：直接顺序执行结构与规格提取（避免图递归）
         if not request.interactive and request.auto_confirm:
             result = await run_build_sequential_async(
                 session_id=session_id,
@@ -210,12 +164,6 @@ async def continue_workflow(request: ContinueWorkflowRequest):
             state["outline_confirmed"] = bool(request.outline_confirmed)
         if request.spec_confirmed is not None:
             state["spec_confirmed"] = bool(request.spec_confirmed)
-        if request.plan_confirmed is not None:
-            state["plan_confirmed"] = bool(request.plan_confirmed)
-        if request.solution_requirements:
-            state["solution_requirements"] = request.solution_requirements
-        if request.user_input:
-            state["user_input"] = request.user_input
 
         # 推进
         state = await _run_interactive_until_pause(state)

--- a/backend/api/v1/endpoints/proposals.py
+++ b/backend/api/v1/endpoints/proposals.py
@@ -13,9 +13,6 @@ def build_proposal(payload: dict = Body(...)):
     result = run_build(session_id, tender_path, wiki_dir, meta)
     return {
         "ok": True,
-        "draft_path": result.get("draft_path"),
         "outline_path": result.get("outline_path"),
         "spec_path": result.get("spec_path"),
-        "plan_path": result.get("plan_path"),
-        "sanity_report": result.get("sanity_report"),
     }

--- a/backend/workflow/bid_build_graph.py
+++ b/backend/workflow/bid_build_graph.py
@@ -2,77 +2,41 @@ from langgraph.graph import StateGraph, END
 from .state import BidState
 from agents.structure_extractor import StructureExtractor
 from agents.spec_extractor import SpecExtractor
-from agents.plan_outliner import PlanOutliner
-from agents.bid_assembler import BidAssembler
-from agents.sanity_checker import SanityChecker
-from agents.solution_optimizer import SolutionOptimizer
+
 
 def build_bid_graph():
-    """构建带用户确认的工作流：结构→[确认]→规格→[确认]→方案→[确认]→拼装→校验"""
+    """构建简化版工作流：结构抽取→规格提取"""
     graph = StateGraph(BidState)
 
-    # 创建agent实例
     structure_extractor = StructureExtractor()
     spec_extractor = SpecExtractor()
-    plan_outliner = PlanOutliner()
-    bid_assembler = BidAssembler()
-    sanity_checker = SanityChecker()
-    solution_optimizer = SolutionOptimizer()
 
-    # 添加节点
     graph.add_node("structure_extractor", structure_extractor.execute)
     graph.add_node("spec_extractor", spec_extractor.execute)
-    # 将“方案提纲”阶段更名为“技术方案”，节点内部仍复用 PlanOutliner 实现
-    graph.add_node("technical_solution", plan_outliner.execute)
-    graph.add_node("bid_assembler", bid_assembler.execute)
-    graph.add_node("sanity_checker", sanity_checker.execute)
-    
-    # 添加确认节点
+
     graph.add_node("await_outline_confirmation", _await_outline_confirmation)
     graph.add_node("await_spec_confirmation", _await_spec_confirmation)
-    # 新增：等待用户输入技术方案需求
-    graph.add_node("await_solution_input", _await_solution_input)
-    # 更名：方案确认 → 技术方案确认
-    graph.add_node("await_solution_confirmation", _await_solution_confirmation)
 
-    # 设置边（带确认的工作流）
     graph.set_entry_point("structure_extractor")
     graph.add_edge("structure_extractor", "await_outline_confirmation")
-    graph.add_conditional_edges("await_outline_confirmation", _check_outline_confirmation, {"spec_extractor": "spec_extractor", "await_outline_confirmation": "await_outline_confirmation"})
-    
+    graph.add_conditional_edges(
+        "await_outline_confirmation",
+        _check_outline_confirmation,
+        {"spec_extractor": "spec_extractor", "await_outline_confirmation": "await_outline_confirmation"},
+    )
+
     graph.add_edge("spec_extractor", "await_spec_confirmation")
     graph.add_conditional_edges(
         "await_spec_confirmation",
         _check_spec_confirmation,
-        {"await_solution_input": "await_solution_input", "await_spec_confirmation": "await_spec_confirmation"}
+        {END: END, "await_spec_confirmation": "await_spec_confirmation"},
     )
-    
-    # 用户输入完成后进入“技术方案”节点
-    graph.add_conditional_edges(
-        "await_solution_input",
-        _check_solution_input,
-        {"technical_solution": "technical_solution", "await_solution_input": "await_solution_input"}
-    )
-
-    graph.add_edge("technical_solution", "await_solution_confirmation")
-    graph.add_conditional_edges(
-        "await_solution_confirmation",
-        _check_solution_confirmation,
-        {"solution_optimizer": "solution_optimizer", "await_solution_confirmation": "await_solution_confirmation"}
-    )
-    
-    # 技术方案优化 → 拼装
-    graph.add_node("solution_optimizer", solution_optimizer.execute)
-    graph.add_edge("solution_optimizer", "bid_assembler")
-    
-    graph.add_edge("bid_assembler", "sanity_checker")
-    graph.add_edge("sanity_checker", END)
 
     return graph.compile()
 
+
 def _await_outline_confirmation(state: BidState) -> BidState:
     """等待用户确认招标文件骨架"""
-    # 在非交互/默认情况下，自动确认以避免无限循环
     if state.get("auto_confirm", True) and not state.get("interactive", False):
         state["outline_confirmed"] = True
         state["waiting_for_confirmation"] = False
@@ -83,9 +47,9 @@ def _await_outline_confirmation(state: BidState) -> BidState:
     state["current_step"] = "outline_confirmation"
     return state
 
+
 def _await_spec_confirmation(state: BidState) -> BidState:
     """等待用户确认技术规格书"""
-    # 在非交互/默认情况下，自动确认以避免无限循环
     if state.get("auto_confirm", True) and not state.get("interactive", False):
         state["spec_confirmed"] = True
         state["waiting_for_confirmation"] = False
@@ -96,78 +60,25 @@ def _await_spec_confirmation(state: BidState) -> BidState:
     state["current_step"] = "spec_confirmation"
     return state
 
-def _await_solution_confirmation(state: BidState) -> BidState:
-    """等待用户确认技术方案"""
-    # 在非交互/默认情况下，自动确认以避免无限循环
-    if state.get("auto_confirm", True) and not state.get("interactive", False):
-        # 复用现有的 plan_confirmed 键，保持向后兼容
-        state["plan_confirmed"] = True
-        state["waiting_for_confirmation"] = False
-        state["current_step"] = "solution_confirmation_auto"
-        return state
-
-    state["waiting_for_confirmation"] = True
-    state["current_step"] = "solution_confirmation"
-    return state
-
-def _await_solution_input(state: BidState) -> BidState:
-    """等待用户输入技术方案需求（基于技术规格书与业务需求）"""
-    # 非交互模式下尝试自动提供占位输入，避免停滞
-    if state.get("auto_confirm", True) and not state.get("interactive", False):
-        # 若上游通过 meta 传入了需求，优先采用
-        meta = state.get("meta", {}) or {}
-        if meta.get("solution_requirements") and not state.get("solution_requirements"):
-            state["solution_requirements"] = meta.get("solution_requirements")
-        # 兼容：若已有 user_input 则复用
-        if not state.get("solution_requirements") and state.get("user_input"):
-            state["solution_requirements"] = state.get("user_input")
-        # 若仍然没有，提供一个非空占位，允许后续节点继续
-        if not state.get("solution_requirements"):
-            state["solution_requirements"] = "自动占位：依据技术规格书与通用要求生成默认技术方案草稿"
-        state["waiting_for_confirmation"] = False
-        state["current_step"] = "solution_input_auto"
-        return state
-
-    state["waiting_for_confirmation"] = True
-    state["current_step"] = "solution_input"
-    return state
 
 def _check_outline_confirmation(state: BidState) -> str:
     """检查招标文件骨架确认状态"""
     if state.get("outline_confirmed", False):
         return "spec_extractor"
-    else:
-        return "await_outline_confirmation"
+    return "await_outline_confirmation"
+
 
 def _check_spec_confirmation(state: BidState) -> str:
     """检查技术规格书确认状态"""
     if state.get("spec_confirmed", False):
-        return "await_solution_input"
-    else:
-        return "await_spec_confirmation"
+        return END
+    return "await_spec_confirmation"
 
-def _check_solution_confirmation(state: BidState) -> str:
-    """检查技术方案确认状态（复用 plan_confirmed 键）"""
-    if state.get("plan_confirmed", False):
-        return "bid_assembler"
-    else:
-        return "await_solution_confirmation"
-
-def _check_solution_input(state: BidState) -> str:
-    """检查是否已获得用户的技术方案输入/需求"""
-    # 认为以下任一存在即可进入技术方案生成：
-    # 1) solution_requirements（推荐） 2) user_input（兼容）
-    if state.get("solution_requirements") or state.get("user_input"):
-        return "technical_solution"
-    else:
-        return "await_solution_input"
 
 # 便捷触发器
 def run_build(session_id: str, tender_path: str, wiki_dir="wiki", meta=None, recursion_limit: int = 50, interactive: bool = False, auto_confirm: bool = True):
-    """运行最小落地版工作流（同步）"""
+    """运行简化版工作流（同步）"""
     graph = build_bid_graph()
-    
-    # 创建初始状态（默认开启自动确认，非交互，避免等待导致的循环）
     initial_state = BidState({
         "session_id": session_id,
         "tender_path": tender_path,
@@ -177,23 +88,18 @@ def run_build(session_id: str, tender_path: str, wiki_dir="wiki", meta=None, rec
         "auto_confirm": auto_confirm,
         "interactive": interactive,
     })
-    
+
     result = graph.invoke(initial_state, config={"recursion_limit": recursion_limit})
-    
+
     return {
         "outline_path": result.get("outline_path"),
         "spec_path": result.get("spec_path"),
-        "plan_path": result.get("plan_path"),
-        "plan_draft_path": result.get("plan_draft_path"),
-        "draft_path": result.get("draft_path"),
-        "sanity_report_path": result.get("sanity_report_path"),
     }
 
+
 async def run_build_async(session_id: str, uploaded_files: list, wiki_dir="wiki", meta=None, recursion_limit: int = 50, interactive: bool = False, auto_confirm: bool = True):
-    """运行最小落地版工作流（异步，保持兼容性）"""
+    """运行简化版工作流（异步，保持兼容性）"""
     graph = build_bid_graph()
-    
-    # 创建初始状态（默认开启自动确认，非交互）
     initial_state = BidState({
         "session_id": session_id,
         "uploaded_files": uploaded_files,
@@ -203,21 +109,17 @@ async def run_build_async(session_id: str, uploaded_files: list, wiki_dir="wiki"
         "auto_confirm": auto_confirm,
         "interactive": interactive,
     })
-    
+
     result = await graph.ainvoke(initial_state, config={"recursion_limit": recursion_limit})
-    
+
     return {
         "outline_path": result.get("outline_path"),
         "spec_path": result.get("spec_path"),
-        "plan_path": result.get("plan_path"),
-        "plan_draft_path": result.get("plan_draft_path"),
-        "draft_path": result.get("draft_path"),
-        "sanity_report_path": result.get("sanity_report_path"),
     }
 
 
 async def run_build_sequential_async(session_id: str, uploaded_files: list, wiki_dir="wiki", meta=None, interactive: bool = False, auto_confirm: bool = True) -> dict:
-    """顺序执行版 A–E 工作流，避免图递归导致的上限问题。"""
+    """顺序执行版工作流，避免图递归导致的上限问题。"""
     state = BidState({
         "session_id": session_id,
         "uploaded_files": uploaded_files,
@@ -244,34 +146,7 @@ async def run_build_sequential_async(session_id: str, uploaded_files: list, wiki
         return state
     state["spec_confirmed"] = True
 
-    # 方案输入
-    if interactive:
-        if not state.get("solution_requirements") and not state.get("user_input"):
-            state["waiting_for_confirmation"] = True
-            state["current_step"] = "solution_input"
-            return state
-    if state.get("solution_requirements") and not state.get("user_input"):
-        state["user_input"] = state["solution_requirements"]
-    if not state.get("solution_requirements"):
-        state["solution_requirements"] = state.get("user_input") or "自动占位：依据技术规格书与通用要求生成默认技术方案草稿"
-
-    # 技术方案
-    state = PlanOutliner().execute(state)
-    if interactive and not state.get("plan_confirmed"):
-        state["waiting_for_confirmation"] = True
-        state["current_step"] = "solution_confirmation"
-        return state
-    state["plan_confirmed"] = True
-
-    # 拼装与校验
-    state = BidAssembler().execute(state)
-    state = SanityChecker().execute(state)
-
     return {
         "outline_path": state.get("outline_path"),
         "spec_path": state.get("spec_path"),
-        "plan_path": state.get("plan_path"),
-        "plan_draft_path": state.get("plan_draft_path"),
-        "draft_path": state.get("draft_path"),
-        "sanity_report_path": state.get("sanity_report_path"),
     }

--- a/backend/workflow/bid_graph.py
+++ b/backend/workflow/bid_graph.py
@@ -4,25 +4,16 @@ from langgraph.graph import StateGraph, END
 
 from agents.structure_extractor import StructureExtractor
 from agents.spec_extractor import SpecExtractor
-from agents.plan_outliner import PlanOutliner
-from agents.bid_assembler import BidAssembler
-from agents.sanity_checker import SanityChecker
 
 def build_bid_graph(State=dict):
     graph = StateGraph(State)
 
     graph.add_node("structure_extractor", StructureExtractor().execute)
     graph.add_node("spec_extractor", SpecExtractor().execute)
-    graph.add_node("plan_outliner", PlanOutliner().execute)
-    graph.add_node("bid_assembler", BidAssembler().execute)
-    graph.add_node("sanity_checker", SanityChecker().execute)
 
     graph.set_entry_point("structure_extractor")
     graph.add_edge("structure_extractor", "spec_extractor")
-    graph.add_edge("spec_extractor", "plan_outliner")
-    graph.add_edge("plan_outliner", "bid_assembler")
-    graph.add_edge("bid_assembler", "sanity_checker")
-    graph.add_edge("sanity_checker", END)
+    graph.add_edge("spec_extractor", END)
     return graph.compile()
 
 def run_build(session_id: str, tender_path: str, wiki_dir="wiki", meta=None) -> Dict[str, Any]:

--- a/backend/workflow/state.py
+++ b/backend/workflow/state.py
@@ -1,5 +1,4 @@
 from typing import Dict, Any, List, Optional, TypedDict
-from langgraph.graph import StateGraph, END
 from pydantic import BaseModel
 
 
@@ -29,26 +28,13 @@ class BidState(TypedDict, total=False):
     bid_md_path: str          # /wiki/投标文件.md（你已有）
     outline_path: str         # /wiki/投标文件_骨架.md
     spec_path: str            # /wiki/技术规格书_提取.md
-    plan_path: str            # /wiki/技术方案.md（原 方案_提纲.md）
-    plan_draft_path: str      # /wiki/技术方案_草稿.md（原 方案_草稿.md）
-    draft_path: str           # /wiki/投标文件_草案.md
-    final_bid_path: str       # /wiki/投标文件.md
-    diff_table_path: str      # /wiki/偏差表.md
-    qa_report_path: str       # /wiki/qa_report.json
     wiki_dir: str             # 输出目录
     meta: Dict[str, Any]      # 项目名/编号/投标人等
     outline_sections: List[str]  # 提取的章节列表
     spec_extracted: bool      # 是否成功提取规格书
-    sanity_report: Dict[str, Any]  # 校验报告
-    sanity_report_path: str   # 校验报告路径
-    compliance_report: Dict[str, Any]
-    compliance_report_path: str
     # 用户确认状态
     outline_confirmed: bool   # 招标文件骨架是否确认
     spec_confirmed: bool      # 技术规格书是否确认
-    plan_confirmed: bool      # 方案提纲是否确认
-    user_input: str           # 用户输入的方案要求
-    solution_requirements: str  # 用户输入的技术方案需求（新）
     current_step: str         # 当前步骤
     waiting_for_confirmation: bool  # 是否等待用户确认
 


### PR DESCRIPTION
## Summary
- cut bid generation workflow to only run StructureExtractor and SpecExtractor with confirmation steps
- expose interactive start/continue workflow endpoints returning outline and spec paths
- coordinator triggers document parsing before executing simplified bid build
- drop unused imports in bid state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68be14d5a600832399905303dba8dcdc